### PR TITLE
Parser optimizations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/dchest/uniuri v1.2.0
-	github.com/indigo-web/utils v0.1.1
+	github.com/indigo-web/utils v0.1.3
 	github.com/stretchr/testify v1.8.4
 )
 

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/dchest/uniuri v1.2.0/go.mod h1:fSzm4SLHzNZvWLvWJew423PhAzkpNQYq+uNLq4
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/indigo-web/utils v0.1.1 h1:6368QFWfenf/9kqZxDF8oWCGGiUmcxJTNSTjra9GS/c=
 github.com/indigo-web/utils v0.1.1/go.mod h1:fBdCfyNyprkgC0FvqaLE1B43CZgByQyhjDRxz4pNt8U=
+github.com/indigo-web/utils v0.1.3 h1:eLlNmB+J+OJOX12TxhhIXKohvBUT+knr9cxpCVrwbS0=
+github.com/indigo-web/utils v0.1.3/go.mod h1:fBdCfyNyprkgC0FvqaLE1B43CZgByQyhjDRxz4pNt8U=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421 h1:ZqeYNhU3OHLH3mGKHDcjJRFFRrJa6eAM5H+CtDdOsPc=

--- a/http/headers/headers.go
+++ b/http/headers/headers.go
@@ -1,5 +1,7 @@
 package headers
 
+import "github.com/indigo-web/indigo/internal/strcomp"
+
 type Iterator[T any] func() (element T, continue_ bool)
 
 // Headers is a struct that encapsulates headers map from user, allowing only
@@ -48,7 +50,7 @@ func (h *Headers) Value(key string) string {
 // ValueOr returns a header value
 func (h *Headers) ValueOr(key, or string) string {
 	for i := 0; i < len(h.headers); i += 2 {
-		if h.headers[i] == key {
+		if strcomp.EqualFold(h.headers[i], key) {
 			return h.headers[i+1]
 		}
 	}
@@ -65,7 +67,7 @@ func (h *Headers) ValuesIter(key string) Iterator[string] {
 		}
 
 		for ; offset < len(h.headers); offset += 2 {
-			if h.headers[offset] == key {
+			if strcomp.EqualFold(h.headers[offset], key) {
 				value := h.headers[offset+1]
 				offset += 2
 
@@ -97,7 +99,7 @@ func (h *Headers) Add(key, value string) {
 // Has returns true or false depending on whether such a key exists
 func (h *Headers) Has(key string) bool {
 	for i := 0; i < len(h.headers); i += 2 {
-		if h.headers[i] == key {
+		if strcomp.EqualFold(h.headers[i], key) {
 			return true
 		}
 	}
@@ -137,7 +139,7 @@ func collectIterator(iter Iterator[string]) (values []string) {
 
 func contains(elements []string, key string) bool {
 	for i := range elements {
-		if elements[i] == key {
+		if strcomp.EqualFold(elements[i], key) {
 			return true
 		}
 	}

--- a/http/request.go
+++ b/http/request.go
@@ -19,13 +19,10 @@ type (
 	Params = map[string]string
 
 	Path struct {
-		String   string
-		Params   Params
-		Query    query.Query
-		Fragment Fragment
+		String string
+		Params Params
+		Query  query.Query
 	}
-
-	Fragment = string
 )
 
 // Request struct represents http request
@@ -124,7 +121,6 @@ func (r *Request) WasHijacked() bool {
 // Clear resets request headers and reads body into nowhere until completed.
 // It is implemented to clear the request object between requests
 func (r *Request) Clear() (err error) {
-	r.Path.Fragment = ""
 	r.Path.Query.Set(nil)
 	r.Ctx = context.Background()
 	r.response = r.response.Clear()

--- a/indigo_test.go
+++ b/indigo_test.go
@@ -80,7 +80,6 @@ func getStaticRouter(t *testing.T) router.Router {
 		require.Equal(t, method.GET, request.Method)
 		_, err := request.Path.Query.Get("some non-existing query key")
 		require.Error(t, err)
-		require.Empty(t, request.Path.Fragment)
 		require.Equal(t, proto.HTTP11, request.Proto)
 
 		return http.RespondTo(request)
@@ -91,7 +90,7 @@ func getStaticRouter(t *testing.T) router.Router {
 	})
 
 	r.Get("/get-read-body", func(request *http.Request) http.Response {
-		require.Contains(t, request.Headers.Unwrap(), testHeaderKey)
+		require.True(t, request.Headers.Has(testHeaderKey))
 		requestHeader := strings.Join(request.Headers.Values(testHeaderKey), ",")
 		require.Equal(t, testHeaderValue, requestHeader)
 
@@ -370,14 +369,12 @@ func TestServer_Static(t *testing.T) {
 		// are empty strings. Remove them
 		headerLines = headerLines[:len(headerLines)-2]
 		wantHeaderLines := []string{
-			"hello: World!",
-			"host: " + addr,
-			"user-agent: Go-http-client/1.1",
-			"accept-encoding: gzip",
-			"content-length: 0",
+			"Hello: World!",
+			"Host: " + addr,
+			"User-Agent: Go-http-client/1.1",
+			"Accept-Encoding: gzip",
+			"Content-Length: 0",
 		}
-
-		require.Equal(t, len(wantHeaderLines), len(headerLines))
 
 		for _, line := range headerLines {
 			require.True(t, contains(wantHeaderLines, line), "unwanted header line: "+line)

--- a/initializers.go
+++ b/initializers.go
@@ -21,12 +21,12 @@ func newClient(tcpSettings settings.TCP, conn net.Conn) tcp.Client {
 	return tcp.NewClient(conn, tcpSettings.ReadTimeout, readBuff)
 }
 
-func newKeyValueArenas(s settings.Headers) (*arena.Arena, *arena.Arena) {
-	keyArena := arena.NewArena(
+func newKeyValueArenas(s settings.Headers) (*arena.Arena[byte], *arena.Arena[byte]) {
+	keyArena := arena.NewArena[byte](
 		s.MaxKeyLength*s.Number.Default,
 		s.MaxKeyLength*s.Number.Maximal,
 	)
-	valArena := arena.NewArena(
+	valArena := arena.NewArena[byte](
 		s.ValueSpace.Default,
 		s.ValueSpace.Maximal,
 	)

--- a/internal/parser/http1/requestsparserbench_test.go
+++ b/internal/parser/http1/requestsparserbench_test.go
@@ -1,6 +1,8 @@
 package http1
 
 import (
+	"strconv"
+	"strings"
 	"testing"
 )
 
@@ -17,38 +19,60 @@ func BenchmarkHttpRequestsParser_Parse_GET(b *testing.B) {
 		}
 	})
 
-	b.Run("BiggerGET", func(b *testing.B) {
-		b.SetBytes(int64(len(biggerGET)))
+	b.Run("5 headers", func(b *testing.B) {
+		request := generateRequest(5, "www.google.com", 13)
+		b.SetBytes(int64(len(request)))
 		b.ResetTimer()
 
 		for i := 0; i < b.N; i++ {
-			_, _, _ = parser.Parse(biggerGET)
+			_, _, _ = parser.Parse(request)
 			parser.Release()
 		}
 	})
 
-	tenHeaders := []byte(
-		"GET / HTTP/1.1\r\n" +
-			"Header1: value1\r\n" +
-			"Header2: value2\r\n" +
-			"Header3: value3\r\n" +
-			"ROFL Header: ROFL value\r\n" +
-			"Header-5: value 5\r\n" +
-			"Header-6: haha lol\r\n" +
-			"Header-7: rolling out of laugh\r\n" +
-			"Header-8: sometimes I just wanna chicken fries\r\n" +
-			"Header-9: but having only fried potatoes instead\r\n" +
-			"Header-10: and this is sometimes really annoying\r\n" +
-			"\r\n",
+	b.Run("10 headers", func(b *testing.B) {
+		request := generateRequest(10, "www.google.com", 13)
+		b.SetBytes(int64(len(request)))
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			_, _, err := parser.Parse(request)
+			if err != nil {
+				panic(err)
+			}
+			parser.Release()
+		}
+	})
+
+	b.Run("50 headers", func(b *testing.B) {
+		request := generateRequest(50, "www.google.com", 13)
+		b.SetBytes(int64(len(request)))
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			_, _, err := parser.Parse(request)
+			if err != nil {
+				panic(err)
+			}
+			parser.Release()
+		}
+	})
+}
+
+func generateRequest(headersNum int, hostValue string, contentLengthValue int) (request []byte) {
+	request = append(request,
+		"GET /"+strings.Repeat("a", 500)+" HTTP/1.1\r\n"...,
 	)
 
-	b.Run("TenHeaders", func(b *testing.B) {
-		b.SetBytes(int64(len(tenHeaders)))
-		b.ResetTimer()
+	for i := 0; i < headersNum-2; i++ {
+		request = append(request,
+			"some-random-header-name-nobody-cares-about"+strconv.Itoa(i)+": "+
+				strings.Repeat("b", 100)+"\r\n"...,
+		)
+	}
 
-		for i := 0; i < b.N; i++ {
-			_, _, _ = parser.Parse(tenHeaders)
-			parser.Release()
-		}
-	})
+	request = append(request, "Host: "+hostValue+"\r\n"...)
+	request = append(request, "Content-Length: "+strconv.Itoa(contentLengthValue)+"\r\n"...)
+
+	return append(request, '\r', '\n')
 }

--- a/internal/parser/http1/states.go
+++ b/internal/parser/http1/states.go
@@ -11,8 +11,6 @@ const (
 	eQueryDecode1Char
 	eQueryDecode2Char
 	eFragment
-	eFragmentDecode1Char
-	eFragmentDecode2Char
 	eProto
 	eH
 	eHT
@@ -26,14 +24,10 @@ const (
 	eProtoCRLF
 	eProtoCRLFCR
 	eHeaderKey
-	eHeaderColon
 	eContentLength
 	eContentLengthCR
-	eContentLengthCRLF
 	eContentLengthCRLFCR
 	eHeaderValue
-	eHeaderValueCR
-	eHeaderValueCRLF
 	eHeaderValueCRLFCR
 )
 

--- a/internal/server/http/http_bench_test.go
+++ b/internal/server/http/http_bench_test.go
@@ -125,11 +125,11 @@ func Benchmark_Get(b *testing.B) {
 		hdrs, q, http.NewResponse(), dummy.NewNopConn(), http.NewBody(bodyReader, decode.NewDecoder()),
 		nil, false,
 	)
-	keyArena := arena.NewArena(
+	keyArena := arena.NewArena[byte](
 		s.Headers.MaxKeyLength*s.Headers.Number.Default,
 		s.Headers.MaxKeyLength*s.Headers.Number.Maximal,
 	)
-	valArena := arena.NewArena(
+	valArena := arena.NewArena[byte](
 		s.Headers.ValueSpace.Default, s.Headers.ValueSpace.Maximal,
 	)
 	objPool := pool.NewObjectPool[[]string](20)
@@ -195,11 +195,11 @@ func Benchmark_Post(b *testing.B) {
 		hdrs, q, http.NewResponse(), dummy.NewNopConn(), http.NewBody(reader, decode.NewDecoder()),
 		nil, false,
 	)
-	keyArena := arena.NewArena(
+	keyArena := arena.NewArena[byte](
 		s.Headers.MaxKeyLength*s.Headers.Number.Default,
 		s.Headers.MaxKeyLength*s.Headers.Number.Maximal,
 	)
-	valArena := arena.NewArena(
+	valArena := arena.NewArena[byte](
 		s.Headers.ValueSpace.Default, s.Headers.ValueSpace.Maximal,
 	)
 	objPool := pool.NewObjectPool[[]string](20)

--- a/internal/strcomp/equalfold.go
+++ b/internal/strcomp/equalfold.go
@@ -1,0 +1,15 @@
+package strcomp
+
+func EqualFold(a, b string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	for i := range a {
+		if a[i]|0x20 != b[i]|0x20 {
+			return false
+		}
+	}
+
+	return true
+}

--- a/router/inbuilt/trace.go
+++ b/router/inbuilt/trace.go
@@ -27,9 +27,9 @@ func renderHTTPRequest(request *http.Request, buff []byte) []byte {
 	buff = append(buff, bytes.TrimSpace(proto.ToBytes(request.Proto))...)
 	buff = append(buff, httpchars.CRLF...)
 	buff = requestHeaders(request, buff)
-	buff = append(buff, "content-length: 0\r\n"...)
+	buff = append(buff, "Content-Length: 0\r\n\r\n"...)
 
-	return append(buff, httpchars.CRLF...)
+	return buff
 }
 
 func requestURI(request *http.Request, buff []byte) []byte {
@@ -38,11 +38,6 @@ func requestURI(request *http.Request, buff []byte) []byte {
 	if query := request.Path.Query.Raw(); len(query) > 0 {
 		buff = append(buff, '?')
 		buff = append(buff, query...)
-	}
-
-	if len(request.Path.Fragment) > 0 {
-		buff = append(buff, '#')
-		buff = append(buff, request.Path.Fragment...)
 	}
 
 	return buff

--- a/settings/settings.go
+++ b/settings/settings.go
@@ -129,10 +129,11 @@ func Default() Settings {
 			MaxKeyLength:   100,  // 100 bytes
 			MaxValueLength: 8192, // 8 kilobytes (just like nginx)
 			ValueSpace: HeadersValuesSpace{
-				// for simple requests without many header values this will be enough, I hope
-				Default: 1024,
-				// 128kb as a limit of amount of memory for header values storing
-				Maximal: 128 * 1024,
+				// for simple requests without many heavy-weighted headers must be enough
+				// to avoid a relatively big amount of re-allocations
+				Default: 2048,
+				// 64kb as a limit of amount of memory for header values storing
+				Maximal: 64 * 1024,
 			},
 		},
 		URL: URL{


### PR DESCRIPTION
- Added SIMD support for http1 parser. Now it operates with up to x3 throughtput
- Increased default size for header values storage: 1024b -> 2048b
- Decreased maximal size for header values storage: 128kb -> 64kb
- Now request headers aren't normalized in the underlying structure, but lookups are still case-insensitive
- Removed `http.Request.Path.Fragment` field