### PR TITLE
Requests decoding fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ func main() {
   if err := app.Serve(router); err != nil {
     log.Fatal(err)
   }
-  log.Fatal(app.Serve(router))
 }
 ```
 

--- a/http/headers/wellknown.go
+++ b/http/headers/wellknown.go
@@ -1,16 +1,10 @@
 package headers
 
 type Encoding struct {
-	// Transfer represents Transfer-Encoding header value
-	Transfer struct {
-		Tokens []string
-	}
-
-	// Content represents Content-Encoding header value
-	Content struct {
-		Tokens []string
-	}
-
+	// Transfer represents Transfer-Encoding header value, split by comma
+	Transfer []string
+	// Content represents Content-Encoding header value, split by comma
+	Content []string
 	// Chunked doesn't belong to any of encodings, as it is still must be processed individually
 	Chunked, HasTrailer bool
 }

--- a/http/headers/wellknown.go
+++ b/http/headers/wellknown.go
@@ -1,6 +1,16 @@
 package headers
 
 type Encoding struct {
+	// Transfer represents Transfer-Encoding header value
+	Transfer struct {
+		Tokens []string
+	}
+
+	// Content represents Content-Encoding header value
+	Content struct {
+		Tokens []string
+	}
+
+	// Chunked doesn't belong to any of encodings, as it is still must be processed individually
 	Chunked, HasTrailer bool
-	Tokens              []string
 }

--- a/internal/parser/http1/requestsparser_test.go
+++ b/internal/parser/http1/requestsparser_test.go
@@ -502,68 +502,68 @@ func TestHttpRequestsParser_Parse_Negative(t *testing.T) {
 
 func TestParseEncoding(t *testing.T) {
 	t.Run("empty string", func(t *testing.T) {
-		te, err := parseEncoding(make([]string, 0, 10), "")
+		toks, chunked, err := parseEncodingString(make([]string, 0, 10), "")
 		require.NoError(t, err)
-		require.False(t, te.Chunked)
-		require.Empty(t, te.Tokens)
+		require.False(t, chunked)
+		require.Empty(t, toks)
 	})
 
 	t.Run("only chunked", func(t *testing.T) {
-		te, err := parseEncoding(make([]string, 0, 10), "chunked")
+		toks, chunked, err := parseEncodingString(make([]string, 0, 10), "chunked")
 		require.NoError(t, err)
 
-		require.True(t, te.Chunked)
-		require.Empty(t, te.Tokens)
+		require.True(t, chunked)
+		require.Empty(t, toks)
 	})
 
 	t.Run("only gzip", func(t *testing.T) {
-		te, err := parseEncoding(make([]string, 0, 10), "gzip")
+		toks, chunked, err := parseEncodingString(make([]string, 0, 10), "gzip")
 		require.NoError(t, err)
 
-		require.False(t, te.Chunked)
-		require.Equal(t, []string{"gzip"}, te.Tokens)
+		require.False(t, chunked)
+		require.Equal(t, []string{"gzip"}, toks)
 	})
 
 	t.Run("chunked,gzip without space", func(t *testing.T) {
-		te, err := parseEncoding(make([]string, 0, 10), "chunked,gzip")
+		toks, chunked, err := parseEncodingString(make([]string, 0, 10), "chunked,gzip")
 		require.NoError(t, err)
 
-		require.True(t, te.Chunked)
-		require.Equal(t, []string{"gzip"}, te.Tokens)
+		require.True(t, chunked)
+		require.Equal(t, []string{"gzip"}, toks)
 
-		te, err = parseEncoding(make([]string, 0, 10), "gzip,chunked")
+		toks, chunked, err = parseEncodingString(make([]string, 0, 10), "gzip,chunked")
 		require.NoError(t, err)
-		require.True(t, te.Chunked)
-		require.Equal(t, []string{"gzip"}, te.Tokens)
+		require.True(t, chunked)
+		require.Equal(t, []string{"gzip"}, toks)
 	})
 
 	t.Run("chunked,gzip with space", func(t *testing.T) {
-		te, err := parseEncoding(make([]string, 0, 10), "chunked,  gzip")
+		toks, chunked, err := parseEncodingString(make([]string, 0, 10), "chunked,  gzip")
 		require.NoError(t, err)
 
-		require.True(t, te.Chunked)
-		require.Equal(t, []string{"gzip"}, te.Tokens)
+		require.True(t, chunked)
+		require.Equal(t, []string{"gzip"}, toks)
 
-		te, err = parseEncoding(make([]string, 0, 10), "gzip,  chunked")
+		toks, chunked, err = parseEncodingString(make([]string, 0, 10), "gzip,  chunked")
 		require.NoError(t, err)
-		require.True(t, te.Chunked)
-		require.Equal(t, []string{"gzip"}, te.Tokens)
+		require.True(t, chunked)
+		require.Equal(t, []string{"gzip"}, toks)
 	})
 
 	t.Run("extra commas", func(t *testing.T) {
-		te, err := parseEncoding(make([]string, 0, 10), " , chunked, gzip, ")
+		toks, chunked, err := parseEncodingString(make([]string, 0, 10), " , chunked, gzip, ")
 		require.NoError(t, err)
 
-		require.True(t, te.Chunked)
-		require.Equal(t, []string{"gzip"}, te.Tokens)
+		require.True(t, chunked)
+		require.Equal(t, []string{"gzip"}, toks)
 
-		te, err = parseEncoding(make([]string, 0, 10), " , chunked")
+		toks, chunked, err = parseEncodingString(make([]string, 0, 10), " , chunked")
 		require.NoError(t, err)
-		require.True(t, te.Chunked)
+		require.True(t, chunked)
 	})
 
 	t.Run("overflow tokens limit", func(t *testing.T) {
-		_, err := parseEncoding(make([]string, 0, 1), "gzip,flate,chunked")
+		_, _, err := parseEncodingString(make([]string, 0, 1), "gzip,flate,chunked")
 		require.EqualError(t, err, status.ErrUnsupportedEncoding.Error())
 	})
 }


### PR DESCRIPTION
- Updated decoding requests: now distinguishing Transfer-Encoding and Content-Encoding according to their semantics (Transfer-Encoding is applied at message-level, Content-Encoding at entity-level - the difference is that Transfer-Encoding may encode chunked stream, and Content-Encoding stands for per-chunk encoding)