### PR TITLE
Disconnect IDLE connections silently, return HTTP errors without description, other internal improvements

### DIFF
--- a/http/method/method.go
+++ b/http/method/method.go
@@ -28,38 +28,28 @@ func Parse(str string) Method {
 		} else if str == "PUT" {
 			return PUT
 		}
-
-		return Unknown
 	case 4:
 		if str == "POST" {
 			return POST
 		} else if str == "HEAD" {
 			return HEAD
 		}
-
-		return Unknown
 	case 5:
 		if str == "PATCH" {
 			return PATCH
 		} else if str == "TRACE" {
 			return TRACE
 		}
-
-		return Unknown
 	case 6:
 		if str == "DELETE" {
 			return DELETE
 		}
-
-		return Unknown
 	case 7:
 		if str == "CONNECT" {
 			return CONNECT
 		} else if str == "OPTIONS" {
 			return OPTIONS
 		}
-
-		return Unknown
 	}
 
 	return Unknown

--- a/http/response.go
+++ b/http/response.go
@@ -196,9 +196,7 @@ func (r *Response) Error(err error) *Response {
 	}
 
 	if http, ok := err.(status.HTTPError); ok {
-		return r.
-			Code(http.Code).
-			String(http.Message)
+		return r.Code(http.Code)
 	}
 
 	return r.

--- a/http/status/codes.go
+++ b/http/status/codes.go
@@ -217,10 +217,9 @@ func Text(code Code) Status {
 	}
 }
 
-// CodeStatus returns a pre-defined line with code and status text (including
-// terminating CRLF sequence) in case code is known to server, otherwise empty
-// line is returned
-func CodeStatus(code Code) string {
+// Line returns the whole status line with code included. Be aware, that the returned string also
+// has CRLF in the end
+func Line(code Code) string {
 	switch code {
 	case Continue:
 		return "100 Continue\r\n"

--- a/indi.go
+++ b/indi.go
@@ -185,13 +185,20 @@ func (a *App) run(servers []*tcp.Server) error {
 	return err
 }
 
-// GracefulStop stops accepting new connections and waits until all the already connected clients
-// disconnects
+// GracefulStop stops accepting new connections, but keeps serving old ones.
+//
+// NOTE: the call isn't blocking. So by that, after the method returned, the server
+//
+//	will be still working
 func (a *App) GracefulStop() {
 	a.errCh <- status.ErrGracefulShutdown
 }
 
 // Stop stops the whole application immediately.
+//
+// NOTE: the call isn't blocking. So by that, after the method returned, the server
+//
+//	will still be working
 func (a *App) Stop() {
 	a.errCh <- status.ErrShutdown
 }

--- a/internal/server/http/http_bench_test.go
+++ b/internal/server/http/http_bench_test.go
@@ -171,7 +171,7 @@ func newServer(client tcp.Client) (*Server, *http.Request, transport.Transport) 
 	request := initialize.NewRequest(settings.Default(), dummy.NewNopConn(), body)
 	trans := initialize.NewTransport(settings.Default(), request)
 
-	return NewServer(r), request, trans
+	return NewServer(r, nil), request, trans
 }
 
 func disperse(data []byte, n int) (parts [][]byte) {

--- a/internal/server/tcp/server.go
+++ b/internal/server/tcp/server.go
@@ -31,6 +31,10 @@ func NewServer(sock net.Listener, onConn OnConn) *Server {
 // Start runs the accept-loop until an error during accepting the connection happens
 // or graceful shutdown invokes
 func (s *Server) Start() error {
+	// we still need the shutdown atomic here, because not every net.Listener
+	// is the Deadliner, too. So by that, in such cases we can't interrupt the
+	// accept-loop via SetDeadline() method. In this case, just wait till the
+	// next client
 	for !s.shutdown.Load() {
 		conn, err := s.sock.Accept()
 		if err != nil {

--- a/internal/transport/http1/serializer.go
+++ b/internal/transport/http1/serializer.go
@@ -98,10 +98,10 @@ func (d *Serializer) Write(
 }
 
 func (d *Serializer) renderResponseLine(fields response.Fields) {
-	codeStatus := status.CodeStatus(fields.Code)
+	statusLine := status.Line(fields.Code)
 
-	if fields.Status == "" && codeStatus != "" {
-		d.buff = append(d.buff, codeStatus...)
+	if fields.Status == "" && statusLine != "" {
+		d.buff = append(d.buff, statusLine...)
 		return
 	}
 

--- a/internal/transport/http1/serializer_bench_test.go
+++ b/internal/transport/http1/serializer_bench_test.go
@@ -148,11 +148,11 @@ func estimateResponseSize(
 	return int64(len(writer.Data)), err
 }
 
-func estimatePreSerializSize(
-	serializer *Serializer, req *http.Request, preSerializ, resp *http.Response,
+func estimatePreWriteSize(
+	serializer *Serializer, req *http.Request, preWrite, resp *http.Response,
 ) (int64, error) {
 	writer := dummy.NewSinkholeWriter()
-	serializer.PreWrite(req.Proto, preSerializ)
+	serializer.PreWrite(req.Proto, preWrite)
 	err := serializer.Write(req.Proto, req, resp, writer)
 
 	return int64(len(writer.Data)), err

--- a/internal/transport/http1/serializer_test.go
+++ b/internal/transport/http1/serializer_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func getSerializer(defaultHeaders map[string]string) *Serializer {
-	return NewSerializer(make([]byte, 0, 1024), 1, defaultHeaders)
+	return NewSerializer(make([]byte, 0, 1024), 128, defaultHeaders)
 }
 
 func newRequest() *http.Request {
@@ -60,13 +60,13 @@ func TestSerializer_Write(t *testing.T) {
 		require.Empty(t, body)
 	})
 
-	testWithHeaders := func(t *testing.T, serialiser *Serializer) {
+	testWithHeaders := func(t *testing.T, serializer *Serializer) {
 		response := http.NewResponse().
 			Header("Hello", "nether").
 			Header("Something", "special", "here")
 
 		writer := new(accumulativeClient)
-		require.NoError(t, serialiser.Write(proto.HTTP11, request, response, writer))
+		require.NoError(t, serializer.Write(proto.HTTP11, request, response, writer))
 		resp, err := stdhttp.ReadResponse(bufio.NewReader(bytes.NewBuffer(writer.Data)), stdreq)
 		require.Equal(t, 200, resp.StatusCode)
 

--- a/router/inbuilt/inbuilt_test.go
+++ b/router/inbuilt/inbuilt_test.go
@@ -203,7 +203,6 @@ func TestRouter_RouteError(t *testing.T) {
 		request := getRequest(method.GET, "/")
 		resp := r.OnError(request, status.ErrNotImplemented)
 		require.Equal(t, status.NotImplemented, resp.Reveal().Code)
-		require.Equal(t, status.ErrNotImplemented.Error(), string(resp.Reveal().Body))
 	})
 
 	t.Run("unregistered ordinary error", func(t *testing.T) {

--- a/settings/settings.go
+++ b/settings/settings.go
@@ -1,6 +1,7 @@
 package settings
 
 import (
+	"github.com/indigo-web/indigo/http"
 	"math"
 	"time"
 
@@ -10,6 +11,8 @@ import (
 var DefaultHeaders = map[string]string{
 	"Accept-Encodings": "identity",
 }
+
+type OnDisconnectCallback func(request *http.Request) *http.Response
 
 type (
 	HeadersNumber struct {
@@ -85,6 +88,8 @@ type (
 		ResponseBuffSize int
 		// FileBuffSize defines the size of the read buffer when reading a file
 		FileBuffSize int
+		// OnDisconnect is a function, that'll be called on client's disconnection
+		OnDisconnect OnDisconnectCallback
 	}
 )
 
@@ -145,6 +150,7 @@ func Default() Settings {
 		HTTP: HTTP{
 			ResponseBuffSize: 1024,
 			FileBuffSize:     64 * 1024, // 64kb read buffer for files is pretty much sufficient
+			OnDisconnect:     nil,
 		},
 	}
 }
@@ -189,6 +195,7 @@ func Fill(src Settings) (new Settings) {
 		HTTP: HTTP{
 			ResponseBuffSize: numOr(src.HTTP.ResponseBuffSize, defaults.HTTP.ResponseBuffSize),
 			FileBuffSize:     numOr(src.HTTP.FileBuffSize, defaults.HTTP.FileBuffSize),
+			OnDisconnect:     nilOr[OnDisconnectCallback](src.HTTP.OnDisconnect, defaults.HTTP.OnDisconnect),
 		},
 	}
 }
@@ -207,4 +214,12 @@ func mapOr[K comparable, V any](custom, defaultVal map[K]V) map[K]V {
 	}
 
 	return custom
+}
+
+func nilOr[T any](custom, defaultVal any) T {
+	if custom == nil {
+		return defaultVal.(T)
+	}
+
+	return custom.(T)
 }


### PR DESCRIPTION
Changelog:
- Now IDLE connections are being actively closed without writing any responses. However, this behavior may be overridden via `Settings.HTTP.OnDisconnect` option
- Calling http.Error() with an HTTPError instance now won't set the request's body to the error's description. This barely affects API, however lets the browser to draw manually better error pages, as simply big white canvas with a small text of the error
- Improved test coverage: added tests for newly introduced OnDisconnect handler, added test for graceful stop
- Minor internal updates