### PR TITLE
v0.17.3

### DIFF
--- a/http/body.go
+++ b/http/body.go
@@ -55,7 +55,11 @@ func (b *Body) Callback(cb func([]byte) error) error {
 		switch b.error {
 		case nil:
 		case io.EOF:
-			return cb(data)
+			if len(data) > 0 {
+				return cb(data)
+			}
+
+			return nil
 		default:
 			return b.error
 		}
@@ -208,13 +212,9 @@ func (b *Body) Reset(request *Request) {
 func (b *Body) multipartBoundary() (boundary string, ok bool) {
 	for key, value := range strutil.WalkKV(strutil.CutParams(b.request.ContentType)) {
 		if key == "boundary" {
-			if len(boundary) != 0 {
-				return "", false
-			}
-
-			boundary = value
+			return value, true
 		}
 	}
 
-	return boundary, true
+	return "", false
 }

--- a/http/body_test.go
+++ b/http/body_test.go
@@ -5,11 +5,167 @@ import (
 	"testing"
 
 	"github.com/indigo-web/indigo/config"
+	"github.com/indigo-web/indigo/http/mime"
+	"github.com/indigo-web/indigo/http/status"
 	"github.com/indigo-web/indigo/transport/dummy"
 	"github.com/stretchr/testify/require"
 )
 
 func TestBody(t *testing.T) {
+	newBody := func(data ...string) *Body {
+		chunks := make([][]byte, len(data))
+		for i, chunk := range data {
+			chunks[i] = []byte(chunk)
+		}
+
+		return NewBody(dummy.NewMockClient(chunks...))
+	}
+
+	t.Run("Callback", func(t *testing.T) {
+		t.Run("happy path", func(t *testing.T) {
+			body := newBody("hello", "world")
+			written := make([]string, 0, 2)
+			err := body.Callback(func(bytes []byte) error {
+				written = append(written, string(bytes))
+				return nil
+			})
+			require.NoError(t, err)
+			require.Equal(t, []string{"hello", "world"}, written)
+		})
+
+		t.Run("error", func(t *testing.T) {
+			body := newBody("hello", "world")
+			var written []string
+			closure := func(bytes []byte) error {
+				written = append(written, string(bytes))
+				return status.ErrBadRequest
+			}
+			err := body.Callback(closure)
+			require.EqualError(t, err, status.ErrBadRequest.Error())
+			require.Equal(t, []string{"hello"}, written)
+
+			err = body.Callback(closure)
+			require.EqualError(t, err, status.ErrBadRequest.Error())
+			require.Equal(t, []string{"hello"}, written)
+		})
+	})
+
+	t.Run("Bytes and String", func(t *testing.T) {
+		newRequest := func(cfg *config.Config, contentLength int, chunked bool) *Request {
+			return &Request{
+				cfg: cfg,
+				commonHeaders: commonHeaders{
+					ContentLength: contentLength,
+					Chunked:       chunked,
+				},
+			}
+		}
+
+		test := func(chunked bool) func(t *testing.T) {
+			return func(t *testing.T) {
+				testHelloworld := func(t *testing.T, cfg *config.Config) {
+					body := newBody("hello", "world")
+					body.request = newRequest(cfg, len("hello")+len("world"), chunked)
+					data, err := body.String()
+					require.NoError(t, err)
+					require.Equal(t, "helloworld", data)
+
+					data, err = body.String()
+					require.NoError(t, err)
+					require.Equal(t, "helloworld", data)
+				}
+
+				t.Run("happy path", func(t *testing.T) {
+					testHelloworld(t, config.Default())
+				})
+
+				t.Run("cap buffer", func(t *testing.T) {
+					cfg := config.Default()
+					cfg.Body.MaxSize = 5
+					testHelloworld(t, cfg)
+				})
+			}
+		}
+
+		t.Run("plain", test(false))
+		t.Run("chunked", test(true))
+	})
+
+	t.Run("JSON", func(t *testing.T) {
+		newRequest := func(mime string) *Request {
+			return &Request{
+				cfg: config.Default(),
+				commonHeaders: commonHeaders{
+					ContentType: mime,
+				},
+			}
+		}
+
+		type sampleModel struct {
+			Hello string `json:"Hello"`
+		}
+
+		const jsonSample = `{"Hello": "world"}`
+
+		parseJSON := func(mime, sample string) (sampleModel, error) {
+			body := newBody(sample)
+			body.request = newRequest(mime)
+
+			var m sampleModel
+			err := body.JSON(&m)
+			return m, err
+		}
+
+		t.Run("happy path", func(t *testing.T) {
+			model, err := parseJSON(mime.JSON, jsonSample)
+			require.NoError(t, err)
+			require.Equal(t, "world", model.Hello)
+		})
+
+		t.Run("incompatible mime", func(t *testing.T) {
+			_, err := parseJSON(mime.HTTP, jsonSample)
+			require.EqualError(t, err, status.ErrUnsupportedMediaType.Error())
+		})
+	})
+
+	t.Run("Form", func(t *testing.T) {
+		newRequest := func(mime string) *Request {
+			return &Request{
+				cfg: config.Default(),
+				commonHeaders: commonHeaders{
+					ContentType: mime,
+				},
+			}
+		}
+
+		t.Run("urlencoded", func(t *testing.T) {
+			body := newBody("hello=world")
+			body.request = newRequest(mime.FormUrlencoded)
+			form, err := body.Form()
+			require.NoError(t, err)
+			world, found := form.Name("hello")
+			require.True(t, found)
+			require.Equal(t, "world", world.Value)
+		})
+
+		t.Run("multipart", func(t *testing.T) {
+			body := newBody("--foo\r\nContent-Disposition: form-data; name=foo\r\n\r\nbar\r\n--foo--\r\n")
+			body.request = newRequest(mime.Multipart + "; boundary=foo")
+			form, err := body.Form()
+			require.NoError(t, err)
+			bar, found := form.Name("foo")
+			require.True(t, found)
+			require.Equal(t, "bar", bar.Value)
+		})
+
+		t.Run("incompatible", func(t *testing.T) {
+			body := newBody("hello")
+			body.request = newRequest(mime.HTTP)
+			_, err := body.Form()
+			require.EqualError(t, err, status.ErrUnsupportedMediaType.Error())
+		})
+	})
+
 	t.Run("reader", func(t *testing.T) {
 		data := dummy.NewMockClient([]byte("Hello, world!"))
 		request := &Request{cfg: config.Default()}

--- a/http/form/form.go
+++ b/http/form/form.go
@@ -12,7 +12,17 @@ type Data struct {
 
 type Form []Data
 
-func (f Form) Name(name string) iter.Seq[Data] {
+// Name returns the first Data matching the name.
+func (f Form) Name(name string) (Data, bool) {
+	for data := range f.Names(name) {
+		return data, true
+	}
+
+	return Data{}, false
+}
+
+// Names returns an iterator over all Data matching the name.
+func (f Form) Names(name string) iter.Seq[Data] {
 	return func(yield func(Data) bool) {
 		for _, entry := range f {
 			if entry.Name == name {
@@ -24,7 +34,17 @@ func (f Form) Name(name string) iter.Seq[Data] {
 	}
 }
 
-func (f Form) File(name string) iter.Seq[Data] {
+// File returns the first Data matching the filename.
+func (f Form) File(name string) (Data, bool) {
+	for data := range f.Files(name) {
+		return data, true
+	}
+
+	return Data{}, false
+}
+
+// Files returns an iterator over all Data matching the filename.
+func (f Form) Files(name string) iter.Seq[Data] {
 	return func(yield func(Data) bool) {
 		for _, entry := range f {
 			if entry.Filename == name {

--- a/http/mime/common_test.go
+++ b/http/mime/common_test.go
@@ -1,0 +1,13 @@
+package mime
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestComplies(t *testing.T) {
+	for _, tc := range []string{"", JSON, JSON + ";", JSON + ";param"} {
+		require.True(t, Complies(JSON, tc))
+	}
+}

--- a/http/response_test.go
+++ b/http/response_test.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"io"
 	"testing"
 
 	"github.com/indigo-web/indigo/kv"
@@ -17,4 +18,22 @@ func TestResponse(t *testing.T) {
 		contentType := kv.NewFromPairs(resp.fields.Headers).Value("Content-Type")
 		require.Equal(t, "application/json", contentType)
 	})
+}
+
+func TestSliceReader(t *testing.T) {
+	var message []byte
+	r := &sliceReader{data: []byte("Hello, world!")}
+	buff := make([]byte, 5)
+
+	for {
+		n, err := r.Read(buff)
+		message = append(message, buff[:n]...)
+		switch err {
+		case nil:
+		case io.EOF:
+			return
+		default:
+			require.Fail(t, err.Error())
+		}
+	}
 }

--- a/http/status/codes.go
+++ b/http/status/codes.go
@@ -159,7 +159,7 @@ var Statuses = [maxCodeValue]string{
 	NetworkAuthenticationRequired: "Network Authentication Required",
 }
 
-func FromCode(code Code) string {
+func String(code Code) string {
 	const nonstandard = "Nonstandard"
 
 	if int(code) >= len(Statuses) {

--- a/http/status/codes_test.go
+++ b/http/status/codes_test.go
@@ -25,3 +25,9 @@ func Benchmark(b *testing.B) {
 		_ = StringCode(code)
 	}
 }
+
+func TestString(t *testing.T) {
+	require.Equal(t, "Nonstandard", String(1))
+	require.Equal(t, "OK", String(200))
+	require.Equal(t, "Nonstandard", String(maxCodeValue))
+}

--- a/internal/buffer/buffer_test.go
+++ b/internal/buffer/buffer_test.go
@@ -94,6 +94,16 @@ func TestBuffer(t *testing.T) {
 		testTrunc(t, 1)
 		testTrunc(t, 5)
 	})
+
+	t.Run("by single byte", func(t *testing.T) {
+		buff := New(5, 5)
+		for range 5 {
+			require.True(t, buff.AppendByte('a'))
+		}
+
+		require.False(t, buff.AppendByte('a'))
+		require.Equal(t, "aaaaa", string(buff.Finish()))
+	})
 }
 
 func testDiscard(t *testing.T, n int) {

--- a/internal/codecutil/cache_test.go
+++ b/internal/codecutil/cache_test.go
@@ -1,0 +1,45 @@
+package codecutil
+
+import (
+	"testing"
+
+	"github.com/indigo-web/indigo/http/codec"
+	"github.com/stretchr/testify/require"
+)
+
+type mockCodec struct {
+	Instantiated bool
+}
+
+func (m *mockCodec) Token() string {
+	return "mock"
+}
+
+func (m *mockCodec) New() codec.Instance {
+	m.Instantiated = true
+	return nil
+}
+
+func TestLazyInstantiation(t *testing.T) {
+	mock := new(mockCodec)
+	cache := NewCache([]codec.Codec{mock}, "")
+	require.False(t, mock.Instantiated)
+	_ = cache.Get("rand")
+	require.False(t, mock.Instantiated)
+	_ = cache.Get("mock")
+	require.True(t, mock.Instantiated)
+}
+
+func TestAcceptEncoding(t *testing.T) {
+	t.Run("0", func(t *testing.T) {
+		require.Equal(t, "identity", AcceptEncoding([]codec.Codec{}))
+	})
+
+	t.Run("1", func(t *testing.T) {
+		require.Equal(t, "gzip", AcceptEncoding([]codec.Codec{codec.NewGZIP()}))
+	})
+
+	t.Run("2", func(t *testing.T) {
+		require.Equal(t, "gzip, zstd", AcceptEncoding([]codec.Codec{codec.NewGZIP(), codec.NewZSTD()}))
+	})
+}

--- a/internal/protocol/http1/serializer.go
+++ b/internal/protocol/http1/serializer.go
@@ -285,7 +285,7 @@ func (s *serializer) appendStatus(fields *response.Fields) {
 
 	statusText := fields.Status
 	if len(statusText) == 0 {
-		statusText = status.FromCode(fields.Code)
+		statusText = status.String(fields.Code)
 	}
 
 	s.buff = append(s.buff, statusText...)

--- a/router/inbuilt/static_test.go
+++ b/router/inbuilt/static_test.go
@@ -1,0 +1,26 @@
+package inbuilt
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSafePath(t *testing.T) {
+	for _, tc := range []string{
+		"/",
+		"/./",
+		"/./.",
+		"././.",
+	} {
+		require.True(t, isSafe(tc))
+	}
+
+	for _, tc := range []string{
+		"/..",
+		"../",
+		"/../",
+	} {
+		require.False(t, isSafe(tc))
+	}
+}

--- a/transport/supervisor_test.go
+++ b/transport/supervisor_test.go
@@ -1,0 +1,140 @@
+package transport
+
+import (
+	"fmt"
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/indigo-web/indigo/config"
+	"github.com/indigo-web/indigo/http/status"
+	"github.com/stretchr/testify/require"
+)
+
+type transportMock struct {
+	stopped     *atomic.Bool
+	closed      bool
+	bound       bool
+	once        bool
+	loop        time.Duration
+	returnError error
+}
+
+func newMock(loop time.Duration, returnError error, once bool) *transportMock {
+	return &transportMock{
+		stopped:     new(atomic.Bool),
+		once:        once,
+		loop:        loop,
+		returnError: returnError,
+	}
+}
+
+func (t *transportMock) Bind(string) error {
+	t.bound = true
+	return nil
+}
+
+func (t *transportMock) Listen(config.NET, func(conn net.Conn)) error {
+	for !t.stopped.Load() && !t.once {
+		time.Sleep(t.loop)
+	}
+
+	return t.returnError
+}
+
+func (t *transportMock) Stop() {
+	t.stopped.Store(true)
+}
+
+func (t *transportMock) Close() {
+	t.closed = true
+}
+
+func (t *transportMock) Wait() {
+	for !t.stopped.Load() {
+		time.Sleep(1 * time.Millisecond)
+	}
+}
+
+func runParallel(fn func() error) chan error {
+	c := make(chan error)
+
+	go func() {
+		c <- fn()
+	}()
+
+	return c
+}
+
+func runAtMost(sup *Supervisor, timeout time.Duration) error {
+	select {
+	case err := <-runParallel(func() error {
+		return sup.Run(config.Default().NET)
+	}):
+		return err
+	case <-time.After(timeout):
+		return fmt.Errorf("supervisor timeouted")
+	}
+}
+
+func TestSupervisor(t *testing.T) {
+	newSupervisor := func(ts ...*transportMock) (*Supervisor, error) {
+		sup := NewSupervisor()
+		for _, transport := range ts {
+			if err := sup.Add("", transport, nil); err != nil {
+				return nil, err
+			}
+		}
+
+		return &sup, nil
+	}
+
+	t.Run("die without error", func(t *testing.T) {
+		sup, err := newSupervisor(
+			newMock(100*time.Millisecond, nil, false),
+			newMock(200*time.Millisecond, nil, true),
+		)
+		require.NoError(t, err)
+		require.NoError(t, runAtMost(sup, 300*time.Millisecond))
+	})
+
+	t.Run("die with error", func(t *testing.T) {
+		sup, err := newSupervisor(
+			newMock(100*time.Millisecond, nil, false),
+			newMock(200*time.Millisecond, status.ErrCloseConnection, true),
+		)
+		require.NoError(t, err)
+		require.EqualError(t, runAtMost(sup, 300*time.Millisecond), status.ErrCloseConnection.Error())
+	})
+
+	t.Run("stop", func(t *testing.T) {
+		sup, err := newSupervisor(
+			newMock(100*time.Millisecond, nil, false),
+			newMock(200*time.Millisecond, nil, false),
+		)
+		require.NoError(t, err)
+		c := runParallel(func() error {
+			return sup.Run(config.Default().NET)
+		})
+		time.Sleep(200 * time.Millisecond)
+		c2 := runParallel(func() error {
+			sup.Stop()
+			return nil
+		})
+
+		select {
+		case err = <-c2:
+			require.NoError(t, err)
+		case <-time.After(300 * time.Millisecond):
+			require.Fail(t, "supervisor did not stop on time")
+		}
+
+		select {
+		case err = <-c:
+			require.NoError(t, err)
+		case <-time.After(50 * time.Millisecond):
+			require.Fail(t, "supervisor did not stop running on time")
+		}
+	})
+}


### PR DESCRIPTION
Final v0.17.3 release version.

Changes:
- improved code coverage
- updated form: now selectors `Name()` and `File()` return the first matching entry. An iterator over all matching entries is now returned by selectors `Names()` and `Files()`
- added safeguards, so stopping the server approximately simultaneously from multiple callsites won't result in being stuck forever