### PR TITLE
v0.17.3.1

### DIFF
--- a/internal/protocol/http1/parser.go
+++ b/internal/protocol/http1/parser.go
@@ -152,9 +152,6 @@ path:
 				if len(data[i+1:]) >= 2 {
 					// fast path
 					c := (hexconv.Halfbyte[data[i+1]] << 4) | hexconv.Halfbyte[data[i+2]]
-					if strutil.IsASCIINonprintable(c) {
-						return true, nil, status.ErrBadRequest
-					}
 					if strutil.IsURLUnsafeChar(c) {
 						data[i+1] |= 0x20
 						data[i+2] |= 0x20
@@ -234,9 +231,6 @@ pathDecode2Char:
 		}
 
 		char := (hexconv.Halfbyte[p.urlEncodedChar] << 4) | hexconv.Halfbyte[data[0]]
-		if strutil.IsASCIINonprintable(char) {
-			return true, nil, status.ErrBadRequest
-		}
 		if strutil.IsURLUnsafeChar(char) {
 			if !requestLine.AppendBytes('%', p.urlEncodedChar|0x20, data[0]|0x20) {
 				return true, nil, status.ErrURITooLong
@@ -350,9 +344,6 @@ paramsValue:
 				if len(data[i+1:]) >= 2 {
 					// fast path
 					c := (hexconv.Halfbyte[data[i+1]] << 4) | hexconv.Halfbyte[data[i+2]]
-					if strutil.IsASCIINonprintable(c) {
-						return true, nil, status.ErrBadParams
-					}
 
 					if !requestLine.AppendByte(c) {
 						return true, nil, status.ErrTooLongRequestLine
@@ -412,9 +403,6 @@ paramsValueDecode2Char:
 		}
 
 		char := (hexconv.Halfbyte[p.urlEncodedChar] << 4) | hexconv.Halfbyte[data[0]]
-		if strutil.IsASCIINonprintable(char) {
-			return true, nil, status.ErrBadParams
-		}
 
 		if !requestLine.AppendByte(char) {
 			return true, nil, status.ErrTooLongRequestLine

--- a/internal/strutil/url.go
+++ b/internal/strutil/url.go
@@ -8,7 +8,7 @@ import (
 
 // IsURLUnsafeChar tells whether it's safe to decode an urlencoded character.
 func IsURLUnsafeChar(c byte) bool {
-	return c == '/'
+	return c == '/' || IsASCIINonprintable(c)
 }
 
 // URLDecode decodes an urlencoded string and tells whether the string was properly formed.
@@ -37,9 +37,6 @@ func URLDecode(str string) (string, bool) {
 		}
 
 		char := (x << 4) | y
-		if IsASCIINonprintable(char) {
-			return "", false
-		}
 		if IsURLUnsafeChar(char) {
 			b.Write([]byte{'%', c1 | 0x20, c2 | 0x20})
 			continue

--- a/internal/strutil/url_test.go
+++ b/internal/strutil/url_test.go
@@ -19,15 +19,9 @@ func TestURLDecode(t *testing.T) {
 		}
 	})
 
-	t.Run("unsafe char", func(t *testing.T) {
-		res, ok := URLDecode("%61%2f")
+	t.Run("unsafe char normalization", func(t *testing.T) {
+		res, ok := URLDecode("%61%2f%D0")
 		require.True(t, ok)
-		require.Equal(t, "a%2f", res)
-	})
-
-	t.Run("unsafe normalization", func(t *testing.T) {
-		res, ok := URLDecode("%61%2F")
-		require.True(t, ok)
-		require.Equal(t, "a%2f", res)
+		require.Equal(t, "a%2f%d0", res)
 	})
 }


### PR DESCRIPTION
Hotfix for v0.17.3 release.

Changes:
- allow urlencoded nonprintable characters in request path and param values. They are moved to unsafe category, and thereby won't be automatically urldecoded.